### PR TITLE
[feat] zustand 의존성 추가 및 readme 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ components                       # 컴포넌트 (공통 & 각 페이지별로 �
 └─ ...
 hooks                            # 커스텀 훅
 utils                            # 의존성없이 static한 function
+stores                           # zustand의 store 관리
 
 ```
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-plugin-storybook": "^0.6.13",
         "prettier": "^3.0.1",
-        "storybook": "^7.2.3"
+        "storybook": "^7.2.3",
+        "zustand": "^4.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -17215,6 +17216,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -17757,6 +17767,34 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
+      "dev": true,
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-plugin-storybook": "^0.6.13",
     "prettier": "^3.0.1",
-    "storybook": "^7.2.3"
+    "storybook": "^7.2.3",
+    "zustand": "^4.4.1"
   }
 }

--- a/stores/authStore.tsx
+++ b/stores/authStore.tsx
@@ -1,0 +1,1 @@
+import { create } from 'zustand';


### PR DESCRIPTION
## PR 요약

> zustand를 사용함에 있어서 따로 보일러플레이트를 작성하지 않아도 된다고 판단했다. 
따라서, zustand를 추가하고 store을 관리할 stores 폴더와 추후에 유저 state를 관리할 authStore을 생성했고, 
별다른 작업을 하지 않았다. 관련 사항은 노션 개발 레퍼런스 항목에 정리했다.

## 변경된 점

> zustand추가, stores/authStore.tsx 추가, readme 수정

## 이슈 번호

> X
